### PR TITLE
fix: Fix exception when accessing empty multiple relations

### DIFF
--- a/src/JsonApiModel.php
+++ b/src/JsonApiModel.php
@@ -50,7 +50,10 @@ class JsonApiModel
 
     protected function getRelationMultiple(string $relationShipName, string $modelClassName): Collection
     {
-        $relation = $this->dataItem->getRelations()[$relationShipName];
+        $relation = $this->dataItem->getRelations()[$relationShipName] ?? null;
+        if (! isset($relation)) {
+            return new Collection();
+        }
         if (!$relation->hasAssociated()) {
             $self = $this->fetchSelfWithInclude($relationShipName);
             return $self->getRelationMultiple($relationShipName, $modelClassName);


### PR DESCRIPTION
Similar fix for 'Call to a member function hasAssociated() on null' error as already applied for single releations.